### PR TITLE
Fixed line continuation

### DIFF
--- a/fortress/lib/unwrapped_line.py
+++ b/fortress/lib/unwrapped_line.py
@@ -100,7 +100,7 @@ class UnwrappedLine:
         self.line = match.group(2)
       # otherwise check for continuation
       #elif len(self.line) > 5 and self.line[0] != "\t" and self.line[5] not in [' ', '0']:
-      elif len(self.line) > 5 and self.line[5] == "&":
+      elif len(self.line) > 5 and self.line[5] not in [' ', '0']:
         self.fixedCont = self.line[:6]
         self.isContinuation = True
         self.line = self.line[6:]


### PR DESCRIPTION
I noticed that it sometimes wouldn't recognise line continuations, and I believe the fortran standard says that "Continuation lines are identified by a nonblank, nonzero in column 6." (source https://docs.oracle.com/cd/E19957-01/805-4939/6j4m0vn6l/index.html).